### PR TITLE
Prevent javascript URLs warning in React 16.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flipbyte/formik-json",
-    "version": "0.4.1-beta.5",
+    "version": "0.4.1-beta.6",
     "description": "formik-json is a wrapper for Formik to easily create forms using JSON / Javascript Object for defining the elements",
     "main": "lib/index.js",
     "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flipbyte/formik-json",
-    "version": "0.4.1-beta.1",
+    "version": "0.4.1-beta.5",
     "description": "formik-json is a wrapper for Formik to easily create forms using JSON / Javascript Object for defining the elements",
     "main": "lib/index.js",
     "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flipbyte/formik-json",
-    "version": "0.4.1",
+    "version": "0.4.1-beta.1",
     "description": "formik-json is a wrapper for Formik to easily create forms using JSON / Javascript Object for defining the elements",
     "main": "lib/index.js",
     "module": "es/index.js",
@@ -10,10 +10,6 @@
         "lib",
         "umd"
     ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/flipbyte/formik-json-schema.git"
-    },
     "scripts": {
         "build": "nwb build-react-component --copy-files",
         "clean": "nwb clean-module && nwb clean-demo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flipbyte/formik-json",
-    "version": "0.4.1-beta.6",
+    "version": "0.4.1-beta.7",
     "description": "formik-json is a wrapper for Formik to easily create forms using JSON / Javascript Object for defining the elements",
     "main": "lib/index.js",
     "module": "es/index.js",

--- a/src/Container/Tabs.js
+++ b/src/Container/Tabs.js
@@ -78,7 +78,7 @@ const Tabs = ({ config = {} }) => {
                                     const tabInvalid = tabValidations.next().value === true;
                                     return <a
                                         key={ key }
-                                        href="javascript:void(null)"
+                                        href="#"
                                         className={
                                             tabListItemClass + ( activeTab == key ? tabActiveClass : '' ) +
                                             ( tabInvalid ? ' is-invalid ' : '' )
@@ -89,7 +89,7 @@ const Tabs = ({ config = {} }) => {
                                                 : tabPaneInvalid
                                             : null
                                         )}
-                                        onClick={() => setActiveTab(key)}
+                                        onClick={(e) => {e.preventDefault(); setActiveTab(key)}}
                                     >
                                         { tab }
                                     </a>

--- a/src/Form.js
+++ b/src/Form.js
@@ -20,34 +20,36 @@ const FormikForm = ({ onUpdate, schema, ...formik }) => {
     return <Element config={ schema } />;
 };
 
-const Form = React.forwardRef(({ schema, onUpdate = () => {}, initialValues = {}, ...rest }, ref) => {
+const Form = React.forwardRef(({ schema, onUpdate = () => {}, initialValues = {}, prepareValidationSchemaFromValidationProps = true, ...rest }, ref) => {
     const [ validationSchema, setValidationSchema ] = useState(null);
+    const formProps = { ...rest, initialValues };
 
     /**
      * Initialize validation schema.
      *
      * Convert the validation schema rules from yup-schema array to yup object
      */
-    const initValidationSchema = useCallback(() => {
-        const yupSchema = prepareValidationSchema(schema);
-        const validationSchema = !_.isEmpty(yupSchema) ? new Rules([[ 'object', yupSchema ]]).toYup() : null;
-        setValidationSchema(validationSchema);
-    }, [ schema ]);
+    if(prepareValidationSchemaFromValidationProps) {
+      const initValidationSchema = useCallback(() => {
+          const yupSchema = prepareValidationSchema(schema);
+          const validationSchema = !_.isEmpty(yupSchema) ? new Rules([[ 'object', yupSchema ]]).toYup() : null;
+          setValidationSchema(validationSchema);
+      }, [ schema ]);
 
-    /**
-     * Everytime the schema changes re-initialize validationSchema
-     *
-     * This is has to be done everytime schema changes because,
-     * certain cases may involve dynamically changing form fields based on
-     * certain conditions, routes etc.
-     */
-    useEffect(() => {
-        initValidationSchema();
-    }, [ schema ]);
+      /**
+       * Everytime the schema changes re-initialize validationSchema
+       *
+       * This is has to be done everytime schema changes because,
+       * certain cases may involve dynamically changing form fields based on
+       * certain conditions, routes etc.
+       */
+      useEffect(() => {
+          initValidationSchema();
+      }, [ schema ]);
 
-    const formProps = { ...rest, initialValues };
-    if (null !== validationSchema) {
-        formProps.validationSchema = validationSchema;
+      if (null !== validationSchema) {
+          formProps.validationSchema = validationSchema;
+      }
     }
 
     return (

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -80,11 +80,11 @@ const ElementRenderer = ({
         nextProps.name !== props.name ||
         nextProps.disabled !== props.disabled ||
         getIn(nextProps.formik.values, props.name) !==
-          getIn(props.values, props.name) ||
+          getIn(props.formik.values, props.name) ||
         getIn(nextProps.formik.errors, props.name) !==
-          getIn(props.errors, props.name) ||
+          getIn(props.formik.errors, props.name) ||
         getIn(nextProps.formik.touched, props.name) !==
-          getIn(props.touched, props.name) ||
+          getIn(props.formik.touched, props.name) ||
         Object.keys(nextProps).length !== Object.keys(props).length ||
         nextProps.isSubmitting !== props.isSubmitting
       ) {

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React, { useState, useEffect } from 'react';
-import { Field } from 'formik';
+import { FastField, Field } from 'formik';
 import withFormConfig from './withFormConfig';
 import { containers, fields, templates, FIELD } from './registry';
 import when from '@flipbyte/when-condition';
@@ -45,11 +45,13 @@ const ElementRenderer = ({
         showWhen,
         enabledWhen,
         template,
+        fastField = true
     } = config;
     const { values } = formik;
     const [ canShow, setCanShow ] = useState(showWhen ? false : true);
     const [ disabled, setDisabled ] = useState(enabledWhen ? true : false);
     const currentValue = _.get(values, name);
+    const FormikFieldComponent = fastField ? FastField : Field;
 
     /**
      * If the template is function, assuming it is a react component, use it
@@ -75,7 +77,7 @@ const ElementRenderer = ({
 
     return !!type && canShow && (
         type === FIELD
-            ? <Field name={ name } render={({ field: { value }}) => (
+            ? <FormikFieldComponent name={ name } render={({ field: { value }}) => (
                 <ErrorManager name={ name }>
                     {(error) => (
                         <Template disabled={ disabled } error={ error } { ...config }>

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React, { useState, useEffect } from 'react';
-import { FastField, Field } from 'formik';
+import { FastField, Field, getIn } from 'formik';
 import withFormConfig from './withFormConfig';
 import { containers, fields, templates, FIELD } from './registry';
 import when from '@flipbyte/when-condition';
@@ -75,9 +75,28 @@ const ElementRenderer = ({
         })
     }, [ values ]);
 
+    const shouldUpdate = (nextProps, props) => {
+      if (
+        nextProps.name !== props.name ||
+        nextProps.disabled !== props.disabled ||
+        getIn(nextProps.formik.values, props.name) !==
+          getIn(props.values, props.name) ||
+        getIn(nextProps.formik.errors, props.name) !==
+          getIn(props.errors, props.name) ||
+        getIn(nextProps.formik.touched, props.name) !==
+          getIn(props.touched, props.name) ||
+        Object.keys(nextProps).length !== Object.keys(props).length ||
+        nextProps.isSubmitting !== props.isSubmitting
+      ) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+
     return !!type && canShow && (
         type === FIELD
-            ? <FormikFieldComponent name={ name } render={({ field: { value }}) => (
+            ? <FormikFieldComponent name={ name } disabled={ disabled } shouldUpdate={ shouldUpdate } render={({ field: { value }}) => (
                 <ErrorManager name={ name }>
                     {(error) => (
                         <Template disabled={ disabled } error={ error } { ...config }>


### PR DESCRIPTION
Prevent javascript URLs warning in React 16.9.

React 16.9 adds the following warning:

    Warning: A future version of React will block javascript: URLs as a security precaution. Use event 
    handlers instead if you can. If you need to generate unsafe HTML try using 
    dangerouslySetInnerHTML instead. React was passed "javascript:void(0);".

See https://github.com/facebook/react/issues/16592 for the feature issue
And some related discussions here: https://github.com/facebook/react/issues/16382